### PR TITLE
Added check for empty bindings for bootstrap-project

### DIFF
--- a/charts/bootstrap-project/Chart.yaml
+++ b/charts/bootstrap-project/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.0.1"
 description: A Helm chart for deploying and managing Openshift projects 🦆
 name: bootstrap-project
-version: 0.0.4
+version: 0.0.5
 home: https://github.com/rht-labs/charts
 maintainers:
   - name: springdo

--- a/charts/bootstrap-project/templates/bindings.yaml
+++ b/charts/bootstrap-project/templates/bindings.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.namespaces }}
+{{- range $k :=.Values.namespaces }}
+{{ $ns:= printf "%s" $k.name}}
+{{- if $k.bindings }}
 ---
 apiVersion: v1
 kind: List
@@ -8,8 +11,6 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install
 items:
-{{- range $k :=.Values.namespaces }}
-{{ $ns:= printf "%s" $k.name}}
 {{- range $b := $k.bindings }}
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -28,6 +29,7 @@ items:
 {{- end }}
 {{- if $b.namespace }}
     namespace: "{{ printf "%s" $b.namespace }}"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes: https://github.com/rht-labs/helm-charts/issues/25

```
namespaces:
- name: bob
serviceaccounts:
```

Which gives:

```
---
# Source: bootstrap-project/templates/namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: "bob"
```