### PR TITLE
🙊 jenkins image updated as quay.io 🙊

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.204.1"
 description: A Helm chart for deploying Jenkins on OpenShift with some additional build agents and plugins
 name: jenkins
-version: 0.0.14
+version: 0.0.15
 home: https://github.com/rht-labs/helm-charts
 maintainers:
   - name: springdo

--- a/charts/jenkins/templates/buildconfigs.yaml
+++ b/charts/jenkins/templates/buildconfigs.yaml
@@ -49,9 +49,8 @@ spec:
 {{- if eq .strategy_type "Source" }}
     sourceStrategy:
       from:
-        kind: "ImageStreamTag"
+        kind: {{ .builder_image_kind | default "ImageStreamTag" }}
         name:  "{{ .builder_image_name }}:{{ .builder_image_tag }}"
-        namespace: {{ .builder_image_namespace | default "openshift" | quote }}
 {{- end }}
     {{- if .pull_secret }}
       pullSecret:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -111,8 +111,9 @@ buildconfigs:
     source_repo: https://github.com/rht-labs/s2i-config-jenkins.git
     source_repo_ref: v1.8
     source_context_dir: '/'
-    builder_image_name: jenkins
-    builder_image_tag: '2'
+    builder_image_kind: "DockerImage"
+    builder_image_name: quay.io/openshift/origin-jenkins
+    builder_image_tag: "latest"
   - name: "jenkins-slave-mvn"
     strategy_type: "Docker"
     source_context_dir: "jenkins-slaves/jenkins-slave-mvn"


### PR DESCRIPTION
Since openshift 3x jenkins imagestream points to `registry.redhat.io/openshift3/jenkins-2-rhel7`,  updated buildconfig and values to point as `quay.io/openshift/origin-jenkins` 
(Jenkins templates should be a bit tidy up later on I think 🙈)