### PR TITLE
🦙exit config on timeout 🦙

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -5,6 +5,6 @@ home: https://github.com/rht-labs/helm-charts
 name: sonatype-nexus
 sources:
 - https://github.com/sonatype/nexus-public
-version: 0.0.1
+version: 0.0.2
 maintainers:
   - name: eformat

--- a/charts/sonatype-nexus/templates/config-nexus.txt
+++ b/charts/sonatype-nexus/templates/config-nexus.txt
@@ -31,7 +31,7 @@ curl -s -k -X POST "${NEXUS_URL}/service/rest/beta/repositories/npm/proxy" \
 oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp=sonatype-nexus) -- bash -c 'if ! grep -q "nexus.onboarding.enabled" /nexus-data/etc/nexus.properties; then echo "nexus.onboarding.enabled=false" >> /nexus-data/etc/nexus.properties; fi'
 
 # make groovy script api active
-oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp=sonatype-nexus) -- bash -c 'if ! grep -q "nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then echo "nexus.scripts.allowCreation=true" >> /nexus-data/etc/nexus.properties; fi'
+oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp=sonatype-nexus) -- bash -c 'if ! grep -q "^nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then echo "nexus.scripts.allowCreation=true" >> /nexus-data/etc/nexus.properties; fi'
 
 # restart pod
 echo "restarting nexus..."
@@ -51,7 +51,7 @@ curl -s -X POST "${NEXUS_URL}/service/rest/v1/script" \
 curl -s -X POST -u admin:admin123 --header "Content-Type: text/plain" "${NEXUS_URL}/service/rest/v1/script/labs-static/run" > /dev/null
 
 # disable groovy
-oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp=sonatype-nexus) -- bash -c 'if grep -q "nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then sed -i -e "s|nexus.scripts.allowCreation=true|#nexus.scripts.allowCreation=true|g" /nexus-data/etc/nexus.properties; fi'
+oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp=sonatype-nexus) -- bash -c 'if grep -q "^nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then sed -i -e "s|nexus.scripts.allowCreation=true|#nexus.scripts.allowCreation=true|g" /nexus-data/etc/nexus.properties; fi'
 
 # restart
 echo "restarting nexus..."

--- a/charts/sonatype-nexus/templates/config-nexus.txt
+++ b/charts/sonatype-nexus/templates/config-nexus.txt
@@ -8,7 +8,7 @@ NEXUS_USER=admin:admin123
 NEXUS_URL=https://$(oc -n ${NS} get route nexus -o custom-columns=ROUTE:.spec.host --no-headers)
 
 echo "waiting for nexus pod ready..."
-oc -n ${NS} wait pod -lapp=sonatype-nexus --for=condition=Ready --timeout=300s
+oc -n ${NS} wait pod -lapp=sonatype-nexus --for=condition=Ready --timeout=600s || exit $?
 sleep 2
 
 # helm hosted via rest
@@ -36,7 +36,7 @@ oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --
 # restart pod
 echo "restarting nexus..."
 oc -n ${NS} delete pod -lapp=sonatype-nexus
-oc -n ${NS} wait pod -lapp=sonatype-nexus --for=condition=Ready --timeout=300s
+oc -n ${NS} wait pod -lapp=sonatype-nexus --for=condition=Ready --timeout=300s || exit $?
 sleep 2
 
 # raw hosted not available on new beta rest api


### PR DESCRIPTION
when job runs to configure, it should exit on timeout, not continue
increased timeout for initial pull