### PR TITLE
Install cert-manager and configure custom resources for automated SSL renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ For more info on each chart checkout these!
 * [bootstrap-project](/charts/bootstrap-project)
 * [operatorhub](/charts/operatorhub)
 * [pact-broker](/charts/pact-broker)
+* [cert-manager](/charts/cert-manager)

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ For more info on each chart checkout these!
 * [bootstrap-project](/charts/bootstrap-project)
 * [operatorhub](/charts/operatorhub)
 * [pact-broker](/charts/pact-broker)
-* [cert-manager](/charts/cert-manager)
+* [cert-manager-configs](/charts/cert-manager-configs)

--- a/charts/cert-manager-configs/.helmignore
+++ b/charts/cert-manager-configs/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+ci/

--- a/charts/cert-manager-configs/Chart.yaml
+++ b/charts/cert-manager-configs/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: cert-manager-configs
+version: v0.1.0
+appVersion: v0.1.0
+description: A Helm chart for installing customizations to the cert-manager deployment
+home: https://github.com/rht-labs/helm-charts
+icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+maintainers:
+- name: paulbarfuss
+  email: pbarfuss@redhat.com

--- a/charts/cert-manager-configs/README.md
+++ b/charts/cert-manager-configs/README.md
@@ -33,8 +33,11 @@ helm template cert-manager-configs -f charts/cert-manager-configs/values.yaml ./
 ```
 
 ## Configuration
+
 | Parameter                                        | Description                                                  | Default                               |
 | ------------------------------------------------ | -------------------------------------------------------------| ------------------------------------- |
-| `namespace`                                      | Project name to deploy DevEx tools                           | `labs-ci-cd`                          |
-| `name`                                           | Project name for argocd server                               | `labs-argocd`                         |
-| `instancelabel`                                  | Unique identifier for argocd default label                   | `rht-labs.com/ubiquitous-journey`     |
+| `namespace`                                      | Project name to install cert-manager                         | `cert-manager`                        |
+| `issuer`                                         | Configure an Issuer or ClusterIssuer for cert-manager        | `{}`                                  |
+| `aws`                                            | Configure AWS credentials                                    | `{}`                                  |
+| `certificates`                                   | Configure APIServer, IngressController and custom certs      | `{}`                                  |
+| `cluster`                                        | Enable APIServer and IngressController managed certificates  | `{}`                                  |

--- a/charts/cert-manager-configs/README.md
+++ b/charts/cert-manager-configs/README.md
@@ -31,8 +31,10 @@ While the cert-manager install can be done with mostly default values, these con
 ```bash
 helm template cert-manager-configs -f charts/cert-manager-configs/values.yaml ./charts/cert-manager-configs | oc apply -f -
 ```
-
+ 
 ## Configuration
+
+See comments in [values.yaml](./values.yaml) for more details on configuration
 
 | Parameter                                        | Description                                                  | Default                               |
 | ------------------------------------------------ | -------------------------------------------------------------| ------------------------------------- |

--- a/charts/cert-manager-configs/README.md
+++ b/charts/cert-manager-configs/README.md
@@ -1,0 +1,40 @@
+# cert-manager-openshift-install
+
+## Install cert-manager and CRDs
+
+Install cert-manager following the [installation instructions for Helm v3](https://cert-manager.io/docs/installation/kubernetes/#steps):
+
+```bash
+oc new-project cert-manager
+
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --version v0.15.0 \
+  --set installCRDs=true \
+  --set 'extraArgs={--dns01-recursive-nameservers=8.8.8.8:53\,1.1.1.1:53}'
+```
+
+We are using v0.15.0 due to a bug in v0.15.1 at the moment. Future releases may install cert-manager from the OperatorHub cert-manager operator.
+
+Note the dns01-recursive-nameservers option above is required in most cases for Route53. By default, cert-manager will check dns with /etc/resolv.conf before creating a CertificateRequest, which is undesirable if your node is not pointed to public DNS nameservers.
+
+## Install ClusterIssuer/Issuer and Certificates
+
+Once cert-manager is up and running, use helm to install to install your issuers, create certificates, and point your APIServer and IngressController to the automatically renewable certificates:
+
+While the cert-manager install can be done with mostly default values, these configs require custom values, including DNS secrets in (charts/cert-manager-configs/values.yaml) before you can apply the configs.
+
+
+```bash
+helm template cert-manager-configs -f charts/cert-manager-configs/values.yaml ./charts/cert-manager-configs | oc apply -f -
+```
+
+## Configuration
+| Parameter                                        | Description                                                  | Default                               |
+| ------------------------------------------------ | -------------------------------------------------------------| ------------------------------------- |
+| `namespace`                                      | Project name to deploy DevEx tools                           | `labs-ci-cd`                          |
+| `name`                                           | Project name for argocd server                               | `labs-argocd`                         |
+| `instancelabel`                                  | Unique identifier for argocd default label                   | `rht-labs.com/ubiquitous-journey`     |

--- a/charts/cert-manager-configs/README.md
+++ b/charts/cert-manager-configs/README.md
@@ -25,7 +25,7 @@ Note the dns01-recursive-nameservers option above is required in most cases for 
 
 Once cert-manager is up and running, use helm to install to install your issuers, create certificates, and point your APIServer and IngressController to the automatically renewable certificates:
 
-While the cert-manager install can be done with mostly default values, these configs require custom values, including DNS secrets in (charts/cert-manager-configs/values.yaml) before you can apply the configs.
+While the cert-manager install can be done with mostly default values, these configs require custom values, including DNS secrets in [values.yaml](./charts/cert-manager-configs/values.yaml) before you can apply the configs.
 
 
 ```bash

--- a/charts/cert-manager-configs/README.md
+++ b/charts/cert-manager-configs/README.md
@@ -25,7 +25,7 @@ Note the dns01-recursive-nameservers option above is required in most cases for 
 
 Once cert-manager is up and running, use helm to install to install your issuers, create certificates, and point your APIServer and IngressController to the automatically renewable certificates:
 
-While the cert-manager install can be done with mostly default values, these configs require custom values, including DNS secrets in [values.yaml](./charts/cert-manager-configs/values.yaml) before you can apply the configs.
+While the cert-manager install can be done with mostly default values, these configs require custom values, including DNS secrets in [values.yaml](./values.yaml) before you can apply the configs.
 
 
 ```bash

--- a/charts/cert-manager-configs/templates/AwsSecret.yml
+++ b/charts/cert-manager-configs/templates/AwsSecret.yml
@@ -1,0 +1,13 @@
+{{- if .Values.issuer.dns.enabled }}
+{{- if eq .Values.issuer.provider "route53" }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "aws-secret-access-key-secret"
+  namespace: {{ .Values.namespace }}
+type: Opaque
+data:
+  aws-secret-access-key: {{ .Values.aws.secretAccessKey | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/cert-manager-configs/templates/Certificate.yml
+++ b/charts/cert-manager-configs/templates/Certificate.yml
@@ -1,0 +1,20 @@
+{{- if .Values.certificates }}
+{{- range $certificate := .Values.certificates }}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ $certificate.name }}
+  namespace: {{ $certificate.namespace }}
+spec:
+  secretName: {{ $certificate.name }}
+  issuerRef:
+    name: {{ $certificate.issuerRef }}
+    kind: {{ $certificate.issuerKind }}
+  {{- with $dnsName := .dnsNames }}
+  dnsNames: 
+  {{ toYaml $dnsName | indent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/cert-manager-configs/templates/Certificate.yml
+++ b/charts/cert-manager-configs/templates/Certificate.yml
@@ -12,8 +12,7 @@ spec:
     name: {{ $certificate.issuerRef }}
     kind: {{ $certificate.issuerKind }}
   {{- with $dnsName := .dnsNames }}
-  dnsNames: 
-  {{ toYaml $dnsName | indent 2 }}
+  dnsNames: {{ toYaml $dnsName | nindent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cert-manager-configs/templates/Cluster.yml
+++ b/charts/cert-manager-configs/templates/Cluster.yml
@@ -30,34 +30,7 @@ metadata:
   name: letsencrypt-ca
   namespace: openshift-config
 data:
-  ca-bundle.crt: |
-    -----BEGIN CERTIFICATE-----
-    MIIEkjCCA3qgAwIBAgIQCgFBQgAAAVOFc2oLheynCDANBgkqhkiG9w0BAQsFADA/
-    MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
-    DkRTVCBSb290IENBIFgzMB4XDTE2MDMxNzE2NDA0NloXDTIxMDMxNzE2NDA0Nlow
-    SjELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUxldCdzIEVuY3J5cHQxIzAhBgNVBAMT
-    GkxldCdzIEVuY3J5cHQgQXV0aG9yaXR5IFgzMIIBIjANBgkqhkiG9w0BAQEFAAOC
-    AQ8AMIIBCgKCAQEAnNMM8FrlLke3cl03g7NoYzDq1zUmGSXhvb418XCSL7e4S0EF
-    q6meNQhY7LEqxGiHC6PjdeTm86dicbp5gWAf15Gan/PQeGdxyGkOlZHP/uaZ6WA8
-    SMx+yk13EiSdRxta67nsHjcAHJyse6cF6s5K671B5TaYucv9bTyWaN8jKkKQDIZ0
-    Z8h/pZq4UmEUEz9l6YKHy9v6Dlb2honzhT+Xhq+w3Brvaw2VFn3EK6BlspkENnWA
-    a6xK8xuQSXgvopZPKiAlKQTGdMDQMc2PMTiVFrqoM7hD8bEfwzB/onkxEz0tNvjj
-    /PIzark5McWvxI0NHWQWM6r6hCm21AvA2H3DkwIDAQABo4IBfTCCAXkwEgYDVR0T
-    AQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwfwYIKwYBBQUHAQEEczBxMDIG
-    CCsGAQUFBzABhiZodHRwOi8vaXNyZy50cnVzdGlkLm9jc3AuaWRlbnRydXN0LmNv
-    bTA7BggrBgEFBQcwAoYvaHR0cDovL2FwcHMuaWRlbnRydXN0LmNvbS9yb290cy9k
-    c3Ryb290Y2F4My5wN2MwHwYDVR0jBBgwFoAUxKexpHsscfrb4UuQdf/EFWCFiRAw
-    VAYDVR0gBE0wSzAIBgZngQwBAgEwPwYLKwYBBAGC3xMBAQEwMDAuBggrBgEFBQcC
-    ARYiaHR0cDovL2Nwcy5yb290LXgxLmxldHNlbmNyeXB0Lm9yZzA8BgNVHR8ENTAz
-    MDGgL6AthitodHRwOi8vY3JsLmlkZW50cnVzdC5jb20vRFNUUk9PVENBWDNDUkwu
-    Y3JsMB0GA1UdDgQWBBSoSmpjBH3duubRObemRWXv86jsoTANBgkqhkiG9w0BAQsF
-    AAOCAQEA3TPXEfNjWDjdGBX7CVW+dla5cEilaUcne8IkCJLxWh9KEik3JHRRHGJo
-    uM2VcGfl96S8TihRzZvoroed6ti6WqEBmtzw3Wodatg+VyOeph4EYpr/1wXKtx8/
-    wApIvJSwtmVi4MFU5aMqrSDE6ea73Mj2tcMyo5jMd6jmeWUHK8so/joWUoHOUgwu
-    X4Po1QYz+3dszkDqMp4fklxBwXRsW10KXzPMTZ+sOPAveyxindmjkW8lGy+QsRlG
-    PfZ+G6Z6h7mjem0Y+iWlkYcV4PIWL1iwBi8saCbGS5jN2p8M+X+Q7UNKEkROb3N6
-    KOqkqm57TH2H3eDJAkSnh6/DNFu0Qg==
-    -----END CERTIFICATE-----
+  ca-bundle.crt: {{ .Values.cluster.caBundle | toYaml | indent 2 }}
 
 ---
 apiVersion: config.openshift.io/v1

--- a/charts/cert-manager-configs/templates/Cluster.yml
+++ b/charts/cert-manager-configs/templates/Cluster.yml
@@ -1,0 +1,71 @@
+{{- if .Values.cluster.apiServer.enabled }}
+{{- if .Values.cluster.ingressController.enabled }}
+---
+kind: APIServer
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec:
+  servingCerts:
+    namedCertificates:
+    - names:
+      - {{ .Values.cluster.apiServer.name }}
+      servingCertificate:
+        name: {{ .Values.cluster.apiServer.tlsSecret }}
+
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: ingress-letsencrypt-cert
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: letsencrypt-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIEkjCCA3qgAwIBAgIQCgFBQgAAAVOFc2oLheynCDANBgkqhkiG9w0BAQsFADA/
+    MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
+    DkRTVCBSb290IENBIFgzMB4XDTE2MDMxNzE2NDA0NloXDTIxMDMxNzE2NDA0Nlow
+    SjELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUxldCdzIEVuY3J5cHQxIzAhBgNVBAMT
+    GkxldCdzIEVuY3J5cHQgQXV0aG9yaXR5IFgzMIIBIjANBgkqhkiG9w0BAQEFAAOC
+    AQ8AMIIBCgKCAQEAnNMM8FrlLke3cl03g7NoYzDq1zUmGSXhvb418XCSL7e4S0EF
+    q6meNQhY7LEqxGiHC6PjdeTm86dicbp5gWAf15Gan/PQeGdxyGkOlZHP/uaZ6WA8
+    SMx+yk13EiSdRxta67nsHjcAHJyse6cF6s5K671B5TaYucv9bTyWaN8jKkKQDIZ0
+    Z8h/pZq4UmEUEz9l6YKHy9v6Dlb2honzhT+Xhq+w3Brvaw2VFn3EK6BlspkENnWA
+    a6xK8xuQSXgvopZPKiAlKQTGdMDQMc2PMTiVFrqoM7hD8bEfwzB/onkxEz0tNvjj
+    /PIzark5McWvxI0NHWQWM6r6hCm21AvA2H3DkwIDAQABo4IBfTCCAXkwEgYDVR0T
+    AQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwfwYIKwYBBQUHAQEEczBxMDIG
+    CCsGAQUFBzABhiZodHRwOi8vaXNyZy50cnVzdGlkLm9jc3AuaWRlbnRydXN0LmNv
+    bTA7BggrBgEFBQcwAoYvaHR0cDovL2FwcHMuaWRlbnRydXN0LmNvbS9yb290cy9k
+    c3Ryb290Y2F4My5wN2MwHwYDVR0jBBgwFoAUxKexpHsscfrb4UuQdf/EFWCFiRAw
+    VAYDVR0gBE0wSzAIBgZngQwBAgEwPwYLKwYBBAGC3xMBAQEwMDAuBggrBgEFBQcC
+    ARYiaHR0cDovL2Nwcy5yb290LXgxLmxldHNlbmNyeXB0Lm9yZzA8BgNVHR8ENTAz
+    MDGgL6AthitodHRwOi8vY3JsLmlkZW50cnVzdC5jb20vRFNUUk9PVENBWDNDUkwu
+    Y3JsMB0GA1UdDgQWBBSoSmpjBH3duubRObemRWXv86jsoTANBgkqhkiG9w0BAQsF
+    AAOCAQEA3TPXEfNjWDjdGBX7CVW+dla5cEilaUcne8IkCJLxWh9KEik3JHRRHGJo
+    uM2VcGfl96S8TihRzZvoroed6ti6WqEBmtzw3Wodatg+VyOeph4EYpr/1wXKtx8/
+    wApIvJSwtmVi4MFU5aMqrSDE6ea73Mj2tcMyo5jMd6jmeWUHK8so/joWUoHOUgwu
+    X4Po1QYz+3dszkDqMp4fklxBwXRsW10KXzPMTZ+sOPAveyxindmjkW8lGy+QsRlG
+    PfZ+G6Z6h7mjem0Y+iWlkYcV4PIWL1iwBi8saCbGS5jN2p8M+X+Q7UNKEkROb3N6
+    KOqkqm57TH2H3eDJAkSnh6/DNFu0Qg==
+    -----END CERTIFICATE-----
+
+---
+apiVersion: config.openshift.io/v1
+kind: Proxy
+metadata:
+  name: cluster
+spec:
+  trustedCA:
+    name: letsencrypt-ca
+{{- end }}
+{{- end }}

--- a/charts/cert-manager-configs/templates/ClusterIssuer.yml
+++ b/charts/cert-manager-configs/templates/ClusterIssuer.yml
@@ -1,0 +1,47 @@
+{{- if .Values.issuer.dns.enabled }}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: {{ .Values.issuer.acme.issuerKind }}
+metadata:
+  name: "letsencrypt-{{ .Values.issuer.acme.env }}"
+spec:
+  acme:
+    email: {{ .Values.issuer.acme.emailAddress }}
+    {{- if eq .Values.issuer.acme.env "production" }}
+    server: https://acme-v02.api.letsencrypt.org/directory
+    {{- else }}
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    {{- end }}
+    privateKeySecretRef:
+      name: letsencrypt-account-private-key
+    solvers:
+      {{- if .Values.issuer.acme.selectorZones }}
+      - selector:
+          {{- with .Values.issuer.acme.selectorZones }}
+          dnsZones:
+          {{ toYaml . | indent 2 }}
+          {{- end }}
+      {{- end }}
+
+      {{- if eq .Values.issuer.provider "route53" }}
+        dns01:
+          route53:
+            region: {{ .Values.aws.region }}
+            accessKeyID: {{ .Values.aws.accessKeyId }}
+            secretAccessKeySecretRef:
+              name: "aws-secret-access-key-secret"
+              key: "aws-secret-access-key"
+      {{- end }}
+
+      {{- if eq .Values.issuer.provider "rfc2136" }}
+        dns01:
+          rfc2136:
+            nameserver: {{ .Values.rfc2136.dnsNameServer }}
+            tsigAlgorithm: {{ .Values.rfc2136.tsigKeyAlgorithm }}
+            tsigKeyName: {{ .Values.rfc2136.tsigKeyName }}
+            tsigSecretSecretRef:
+              name: "tsig-key-secret"
+              key: "tsig-key"
+      {{- end }}
+
+{{- end }}

--- a/charts/cert-manager-configs/values.yaml
+++ b/charts/cert-manager-configs/values.yaml
@@ -4,65 +4,65 @@
 namespace: cert-manager
 
 # Setup Issuer and ClusterIssuer custom resources for route53 and rfc2136 resources
-issuer: {}
-  # dns:
-  #   enabled: true
-  # provider: route53
-  # acme:
-  #   emailAddress: admin@example.com
-  #   selectorZones:
-  #     - subdomain.example.com
-  #   env: production
-  #   issuerKind: ClusterIssuer
+issuer:
+  dns:
+    enabled: true
+  provider: route53
+  acme:
+    emailAddress: admin@example.com
+    selectorZones:
+      - subdomain.example.com
+    env: production
+    issuerKind: ClusterIssuer
 
 # AWS credentials scoped to route53 only
 # See https://cert-manager.io/docs/configuration/acme/dns01/route53/#set-up-an-iam-role
-aws: {}
-  # accessKeyId: 
-  # secretAccessKey: 
-  # region: us-east-1
+aws:
+  accessKeyId: ''
+  secretAccessKey: ''
+  region: us-east-1
 
 # rfc2136 credentials for named nsupdate ClusterIssuer
-rfc2136: {}
-  # dnsNameServer:
-  # tsigKeyAlgorithm:
-  # tsigKeyName:
+rfc2136:
+  dnsNameServer: ''
+  tsigKeyAlgorithm: ''
+  tsigKeyName: ''
 
 # Add multiple certificates, including APIServer and IngressController and custom certificates
-certificates: {}
-  # custom:
-  #   name: custom
-  #   namespace: custom
-  #   issuerRef: letsencrypt-production
-  #   issuerKind: ClusterIssuer
-  #   dnsNames:
-  #     - custom.example.com
-  # apiServer:
-  #   name: api-letsencrypt-cert
-  #   namespace: openshift-config
-  #   issuerRef: letsencrypt-production
-  #   issuerKind: ClusterIssuer
-  #   dnsNames:
-  #     - api.example.com
-  # ingressController:
-  #   name: ingress-letsencrypt-cert
-  #   namespace: openshift-ingress
-  #   issuerRef: letsencrypt-production
-  #   issuerKind: ClusterIssuer
-  #   dnsNames:
-  #     - '*.apps.example.com'
+certificates:
+  custom:
+    name: custom
+    namespace: custom
+    issuerRef: letsencrypt-production
+    issuerKind: ClusterIssuer
+    dnsNames:
+      - custom.example.com
+  apiServer:
+    name: api-letsencrypt-cert
+    namespace: openshift-config
+    issuerRef: letsencrypt-production
+    issuerKind: ClusterIssuer
+    dnsNames:
+      - api.example.com
+  ingressController:
+    name: ingress-letsencrypt-cert
+    namespace: openshift-ingress
+    issuerRef: letsencrypt-production
+    issuerKind: ClusterIssuer
+    dnsNames:
+      - '*.apps.example.com'
 
 # Enable along with apiServer and ingressController certificates for automated Openshift SSL certificates
 # The Let's Encrypt CA is available at https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt
-cluster: {}
-  # apiServer:
-  #   enabled: true
-  #   name: api.example.com
-  #   tlsSecret: api-letsencrypt-cert
+cluster:
+  apiServer:
+    enabled: true
+    name: api.example.com
+    tlsSecret: api-letsencrypt-cert
 
-  # ingressController:
-  #   enabled: true
-  # caBundle: |
-  #   -----BEGIN CERTIFICATE-----
-  #   <data>
-  #   -----END CERTIFICATE-----
+  ingressController:
+    enabled: true
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    <data>
+    -----END CERTIFICATE-----

--- a/charts/cert-manager-configs/values.yaml
+++ b/charts/cert-manager-configs/values.yaml
@@ -53,6 +53,7 @@ certificates: {}
   #     - '*.apps.example.com'
 
 # Enable along with apiServer and ingressController certificates for automated Openshift SSL certificates
+# The Let's Encrypt CA is available at https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt
 cluster: {}
   # apiServer:
   #   enabled: true
@@ -61,3 +62,7 @@ cluster: {}
 
   # ingressController:
   #   enabled: true
+  # caBundle: |
+  #   -----BEGIN CERTIFICATE-----
+  #   <data>
+  #   -----END CERTIFICATE-----

--- a/charts/cert-manager-configs/values.yaml
+++ b/charts/cert-manager-configs/values.yaml
@@ -1,0 +1,63 @@
+---
+
+# Default values for cert-manager configs for Openshift APIServer, IngressController and custom routes
+namespace: cert-manager
+
+# Setup Issuer and ClusterIssuer custom resources for route53 and rfc2136 resources
+issuer: {}
+  # dns:
+  #   enabled: true
+  # provider: route53
+  # acme:
+  #   emailAddress: admin@example.com
+  #   selectorZones:
+  #     - subdomain.example.com
+  #   env: production
+  #   issuerKind: ClusterIssuer
+
+# AWS credentials scoped to route53 only
+# See https://cert-manager.io/docs/configuration/acme/dns01/route53/#set-up-an-iam-role
+aws: {}
+  # accessKeyId: 
+  # secretAccessKey: 
+  # region: us-east-1
+
+# rfc2136 credentials for named nsupdate ClusterIssuer
+rfc2136: {}
+  # dnsNameServer:
+  # tsigKeyAlgorithm:
+  # tsigKeyName:
+
+# Add multiple certificates, including APIServer and IngressController and custom certificates
+certificates: {}
+  # custom:
+  #   name: custom
+  #   namespace: custom
+  #   issuerRef: letsencrypt-production
+  #   issuerKind: ClusterIssuer
+  #   dnsNames:
+  #     - custom.example.com
+  # apiServer:
+  #   name: api-letsencrypt-cert
+  #   namespace: openshift-config
+  #   issuerRef: letsencrypt-production
+  #   issuerKind: ClusterIssuer
+  #   dnsNames:
+  #     - api.example.com
+  # ingressController:
+  #   name: ingress-letsencrypt-cert
+  #   namespace: openshift-ingress
+  #   issuerRef: letsencrypt-production
+  #   issuerKind: ClusterIssuer
+  #   dnsNames:
+  #     - '*.apps.example.com'
+
+# Enable along with apiServer and ingressController certificates for automated Openshift SSL certificates
+cluster: {}
+  # apiServer:
+  #   enabled: true
+  #   name: api.example.com
+  #   tlsSecret: api-letsencrypt-cert
+
+  # ingressController:
+  #   enabled: true


### PR DESCRIPTION
@tylerauerbeck Please review when you get a chance. One thing to consider, however we might choose to install these resources, is that cert-manager and related CRDs must be installed before the custom configs (issuers, certificates, APIServer, IngressController)

Still working on configuration values in the README and testing installation methods, but the charts are ready for review.