### PR TITLE
🦜just do a lint. the kind install invariably fails 🦜

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -19,12 +19,15 @@ jobs:
           command: lint
           config: ct.yaml
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-rc.1
-        if: steps.lint.outputs.changed == 'true'
+      # TODO
+      # These checks invariably fail with openshift specific features, features that need pv/pvc
+      # Need a better strategy here
+      # - name: Create kind cluster
+      #   uses: helm/kind-action@v1.0.0-rc.1
+      #   if: steps.lint.outputs.changed == 'true'
 
-      - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-rc.1
-        with:
-          command: install
-          config: ct.yaml
+      # - name: Run chart-testing (install)
+      #   uses: helm/chart-testing-action@v1.0.0-rc.1
+      #   with:
+      #     command: install
+      #     config: ct.yaml


### PR DESCRIPTION
Kind install is always failing for charts that require OCP features, or need PV/PVC's as two obvious examples.

This holds up the automatic releasing of minor chart changes.

We need a better way to test chart install.

Ideally this step just does what it says on the tin "linting"