### PR TITLE
🦔 namespaced rbac for argocd 🦔

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.6.0
+appVersion: v1.6.1
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 0.0.13
+version: 0.0.14
 home: https://github.com/rht-labs/helm-charts
 maintainers:
 - name: springdo

--- a/charts/argocd-operator/templates/ClusterRoleBinding.yaml
+++ b/charts/argocd-operator/templates/ClusterRoleBinding.yaml
@@ -12,8 +12,10 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ .Values.namespace }}-argocd-application-controller
+{{- if not .Values.namespaceRoleBinding.enabled }}
 subjects:
 - kind: ServiceAccount
   name: argocd-application-controller
   namespace: {{ .Values.namespace }}
+{{- end }}
 {{- end }}

--- a/charts/argocd-operator/templates/RoleBinding.yaml
+++ b/charts/argocd-operator/templates/RoleBinding.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.namespaceRoleBinding.enabled }}
+{{- range $key := .Values.namespaceRoleBinding.namespaces }}
+{{ $ns:= printf "%s" .name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: {{ $ns }}-argocd-application-controller
+    app.kubernetes.io/part-of: {{ $ns | quote }}
+  name: {{ $ns }}-argocd-application-controller
+  namespace: {{ $ns | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $ns }}-argocd-application-controller
+subjects:
+- kind: ServiceAccount
+  name: argocd-application-controller
+  namespace: {{ $ns | quote }}
+{{- end }}
+{{- end }}

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -1,9 +1,13 @@
 ---
 # control used by Labs Ubiquitous Journey
 enabled: true
-
 name: labs-argocd
-namespace: labs-ci-cd
+
+ci_cd_namespace: &ci_cd "labs-ci-cd"
+dev_namespace: &dev "labs-dev"
+test_namespace: &test "labs-test"
+
+namespace: *ci_cd
 instancelabel: rht-labs.com/ubiquitous-journey
 
 # operator manages upgrades etc
@@ -55,3 +59,11 @@ accounts:
   accounts.admin: login, apiKey
   accounts.alice: apiKey
   accounts.alice.enabled: "false"
+
+# role bindings, enable this to restrict to listed namespaces only. cluster role by default (enabled: false)
+namespaceRoleBinding:
+  enabled: false
+  namespaces:
+  - name: *ci_cd
+  - name: *dev
+  - name: *test


### PR DESCRIPTION
Add namespace access only for ArgoCD SA as per

https://argoproj.github.io/argo-cd/operator-manual/security/#cluster-rbac

Disabled by default (i.e. get existing cluster role binding). If you set this `enabled: true`, you will get namespace RoleBinding for the argocd service account: 

```
# role bindings, enable this to restrict to listed namespaces only. cluster role by default (enabled: false)
namespaceRoleBinding:
  enabled: true
  namespaces:
  - name: *ci_cd
  - name: *dev
  - name: *test
```

will add overrides into UJ bootstrap values and document.